### PR TITLE
Add missing media projection foreground service permission

### DIFF
--- a/controlcenter_mod/AndroidManifest.xml
+++ b/controlcenter_mod/AndroidManifest.xml
@@ -32,6 +32,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION"/>
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
     <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
     <supports-screens android:anyDensity="true" android:largeScreens="true" android:normalScreens="true"


### PR DESCRIPTION
## Summary
- add the Android 14-required FOREGROUND_SERVICE_MEDIA_PROJECTION permission for the service that uses the mediaProjection foreground service type

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e56a3ae47c832c9d282a010f062650