### PR TITLE
Fix keystore conditional checks in workflow

### DIFF
--- a/.github/workflows/build-mod.yml
+++ b/.github/workflows/build-mod.yml
@@ -8,6 +8,11 @@ jobs:
   build:
     name: Rebuild modded APK
     runs-on: ubuntu-latest
+    env:
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -33,31 +38,25 @@ jobs:
           zipalign -v -p 4 artifacts/ControlCenter15-mod-unsigned.apk artifacts/ControlCenter15-mod-aligned.apk
 
       - name: Decode signing keystore
-        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' }}
-        env:
-          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        if: ${{ env.ANDROID_KEYSTORE_BASE64 != '' }}
         run: |
-          echo "$KEYSTORE_BASE64" | base64 --decode > android-signing-keystore.jks
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > android-signing-keystore.jks
 
       - name: Sign APK
-        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' }}
-        env:
-          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        if: ${{ env.ANDROID_KEYSTORE_BASE64 != '' }}
         run: |
-          KEY_PASS=${KEY_PASSWORD:-$KEYSTORE_PASSWORD}
+          KEY_PASS=${ANDROID_KEY_PASSWORD:-$ANDROID_KEYSTORE_PASSWORD}
           export KEY_PASS
           apksigner sign \
             --ks android-signing-keystore.jks \
-            --ks-pass env:KEYSTORE_PASSWORD \
-            --ks-key-alias "$KEY_ALIAS" \
+            --ks-pass env:ANDROID_KEYSTORE_PASSWORD \
+            --ks-key-alias "$ANDROID_KEY_ALIAS" \
             --key-pass env:KEY_PASS \
             artifacts/ControlCenter15-mod-aligned.apk
           mv artifacts/ControlCenter15-mod-aligned.apk artifacts/ControlCenter15-mod.apk
 
       - name: Use aligned APK when signing is skipped
-        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 == '' }}
+        if: ${{ env.ANDROID_KEYSTORE_BASE64 == '' }}
         run: mv artifacts/ControlCenter15-mod-aligned.apk artifacts/ControlCenter15-mod.apk
 
       - name: Upload rebuilt APK

--- a/controlcenter_mod/AndroidManifest.xml
+++ b/controlcenter_mod/AndroidManifest.xml
@@ -32,6 +32,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION"/>
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
     <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
     <supports-screens android:anyDensity="true" android:largeScreens="true" android:normalScreens="true"


### PR DESCRIPTION
## Summary
- add the Android 14-required FOREGROUND_SERVICE_MEDIA_PROJECTION permission for the service that uses the mediaProjection foreground service type
- expose Android signing secrets through job-level environment variables so conditional steps can detect when signing should run

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e56a3ae47c832c9d282a010f062650